### PR TITLE
fixed cards, navbar, and spacing in faq(mobile)

### DIFF
--- a/components/home/FAQSection.tsx
+++ b/components/home/FAQSection.tsx
@@ -25,20 +25,20 @@ const FAQSection: React.FC = () => {
   };
 
   return (
-    <section className="py-12 bg-gray-50 text-gray-800">
+    <section className="py-12 px-4 bg-gray-50 text-gray-800">
       <div className="max-w-3xl mx-auto text-center mb-8">
         <h2 className="text-3xl font-bold mb-2">Frequently Asked Questions</h2>
         <p className="text-gray-600">Common questions about our Library Management System</p>
       </div>
 
-      <div className="max-w-3xl mx-auto space-y-4">
+      <div className="max-w-3xl mx-auto space-y-4 ">
         {faqs.map((faq, index) => (
           <div
             key={index}
             className="border border-gray-200 rounded-lg shadow-sm bg-white"
           >
             <button
-              className="w-full text-left p-4 font-medium flex justify-between items-center"
+              className="w-full text-left p-4 font-medium flex justify-between items-center cursor-pointer"
               onClick={() => toggleFAQ(index)}
             >
               {faq.question}

--- a/components/home/FeatureSection.tsx
+++ b/components/home/FeatureSection.tsx
@@ -145,7 +145,7 @@ export default function FeatureSection() {
       {/* New Browse Categories Section */}
       <section className="py-16 bg-gray-50">
         <div className="container mx-auto px-6">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8">
             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
               Browse by Category
             </h2>
@@ -159,7 +159,7 @@ export default function FeatureSection() {
             {showLeftArrow && (
               <button
                 onClick={() => scroll('left')}
-                className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-3 shadow-lg hover:bg-gray-100 transition-all"
+                className="absolute cursor-pointer left-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-3 shadow-lg hover:bg-gray-100 transition-all"
                 aria-label="Scroll left"
               >
                 <ChevronLeft className="w-6 h-6 text-gray-700" />
@@ -169,7 +169,7 @@ export default function FeatureSection() {
             <div
               ref={scrollContainerRef}
               onScroll={handleScroll}
-              className="flex gap-6 overflow-x-auto scrollbar-hide scroll-smooth pb-4"
+              className="flex gap-6 overflow-x-auto scrollbar-hide scroll-smooth py-4"
               style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
             >
               {categories.map((category: Category) => {
@@ -218,7 +218,7 @@ export default function FeatureSection() {
             {showRightArrow && (
               <button
                 onClick={() => scroll('right')}
-                className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-3 shadow-lg hover:bg-gray-100 transition-all"
+                className="absolute cursor-pointer right-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-3 shadow-lg hover:bg-gray-100 transition-all"
                 aria-label="Scroll right"
               >
                 <ChevronRight className="w-6 h-6 text-gray-700" />

--- a/components/home/NavbarSection.tsx
+++ b/components/home/NavbarSection.tsx
@@ -59,11 +59,11 @@ export default function NavbarSection(){
     return(
         <nav className="bg-white sticky top-0 z-50 backdrop-blur-lg shadow-gray-300 shadow-md bg-opacity-95">
         <div className="container mx-auto px-6 py-6 flex justify-between items-center">
-          <div className="flex items-center space-x-3">
-            <BookOpenText className="text-indigo-400 w-8 h-8 hover:scale-110 transition-transform duration-300" />
+          <div className="flex cursor-pointer items-center space-x-3 group">
+            <BookOpenText className="text-indigo-400 w-8 h-8 group-hover:opacity-60 transition-transform duration-300" />
             <Link
               href="/"
-              className="text-black text-2xl font-bold tracking-tight hover:text-neutral-400 transition-colors duration-300"
+              className="text-black text-2xl font-bold tracking-tight group-hover:opacity-60 transition-colors duration-300"
             >
               LibraryMS
             </Link>
@@ -72,13 +72,13 @@ export default function NavbarSection(){
           (<div className="space-x-4">
             <Link
               href="/auth/login"
-              className="text-white bg-indigo-600 px-5 py-2.5 rounded-lg hover:bg-indigo-500 hover:border-1 transition-all duration-300 hover:border-neutral-400"
+              className="text-white bg-indigo-600 px-5 py-2.5 rounded-lg hover:bg-indigo-500 transition-all duration-300 "
             >
               Login
             </Link>
             <Link
               href="/auth/register"
-              className="text-white bg-indigo-600 px-5 py-2.5 rounded-lg hover:bg-indigo-500 hover:border-1 transition-all duration-300 hover:border-neutral-400"
+              className="text-white bg-indigo-600 px-5 py-2.5 rounded-lg hover:bg-indigo-500 transition-all duration-300 "
             >
               Sign Up
             </Link>


### PR DESCRIPTION
when hovered on the logo or libraryms text both have effects
When hovering the card the top part no longer becomes straight edge and now stay on being curved
faq accordions now have spacing on its left and right side instead of fully taking the whole screen width (also made it have a pointer cursor)

also fixed the login and signup button where when you hover it it moves and now it no longer moves